### PR TITLE
JENKINS-52432 Pipeline's timeout takes twice the timeout to terminate HubotApprove

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,8 @@
 
 == 2.0.1 (Unreleased)
 
+* https://issues.jenkins-ci.org/browse/JENKINS-52432[JENKINS-52432] - Pipeline's timeout takes twice the timeout to terminate HubotApprove.
+
 == 2.0.0
 
 * https://issues.jenkins-ci.org/browse/JENKINS-50608[JENKINS-50608] - Global site configuration to support multiple hubot servers.

--- a/src/main/java/org/thoughtslive/jenkins/plugins/hubot/steps/ApproveStep.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/hubot/steps/ApproveStep.java
@@ -223,6 +223,7 @@ public class ApproveStep extends BasicHubotStep {
       if (inputExecution != null) {
         inputExecution.stop(cause);
       }
+      getContext().onFailure(cause);
     }
   }
 }


### PR DESCRIPTION
# Description
* Pipeline's timeout takes twice the timeout to terminate HubotApprove
See [JENKINS-52432](https://issues.jenkins-ci.org/browse/JENKINS-52432).
