### PR TITLE
JENKINS-52567 Whitelist ResponseData methods in In-Process approval

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,6 +1,10 @@
 = Release Notes.
 
+== 2.0.3 (Unreleased)
+
 == 2.0.2
+
+* https://issues.jenkins-ci.org/browse/JENKINS-52567[JENKINS-52567] - Whitelist ResponseData methods in In-Process approval.
 
 == 2.0.1
 

--- a/src/main/java/org/thoughtslive/jenkins/plugins/hubot/api/ResponseData.java
+++ b/src/main/java/org/thoughtslive/jenkins/plugins/hubot/api/ResponseData.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 
 /**
  * Common response that every pipeline step would receive.
@@ -21,13 +22,18 @@ public class ResponseData<T> implements Serializable {
 
   private static final long serialVersionUID = -3541969436327716610L;
 
+  @Whitelisted
   private boolean successful;
 
+  @Whitelisted
   private int code;
 
+  @Whitelisted
   private String message;
 
+  @Whitelisted
   private String error;
 
+  @Whitelisted
   private T data;
 }


### PR DESCRIPTION
# Description
* Whitelist ResponseData methods in In-Process approval
See [JENKINS-52567](https://issues.jenkins-ci.org/browse/JENKINS-52567).