### PR TITLE
Resolved mismatch stubbings in SendStepTest.java

### DIFF
--- a/src/test/java/org/thoughtslive/jenkins/plugins/hubot/steps/SendStepTest.java
+++ b/src/test/java/org/thoughtslive/jenkins/plugins/hubot/steps/SendStepTest.java
@@ -65,8 +65,6 @@ public class SendStepTest {
     when(hubotServiceMock.sendMessage(any()))
         .thenReturn(builder.successful(true).code(200).message("Success").build());
 
-    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
-    when(envVarsMock.get("BUILD_URL")).thenReturn("http://localhost:9090/hubot-testing/job/01");
 
     when(contextMock.get(Run.class)).thenReturn(runMock);
     when(contextMock.get(TaskListener.class)).thenReturn(taskListenerMock);
@@ -80,6 +78,8 @@ public class SendStepTest {
 
   @Test
   public void testWithEmptyHubotURLThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
     final SendStep step = new SendStep("message");
     step.setRoom("room");
     stepExecution = new SendStep.SendStepExecution(step, contextMock);
@@ -98,6 +98,8 @@ public class SendStepTest {
 
   @Test
   public void testWithEmptyRoomThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_DEFAULT_ROOM")).thenReturn(null);
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
     final SendStep step = new SendStep("message");
     step.setUrl("http://localhost:9090/");
 
@@ -114,6 +116,8 @@ public class SendStepTest {
 
   @Test
   public void testWithEmptyMessageThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("BUILD_URL")).thenReturn("http://localhost:9090/hubot-testing/job/01");
     final SendStep step = new SendStep("");
     step.setRoom("room");
     stepExecution = new SendStep.SendStepExecution(step, contextMock);
@@ -128,6 +132,9 @@ public class SendStepTest {
 
   @Test
   public void testErrorMessageSend() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
+    when(envVarsMock.get("CHANGE_AUTHOR")).thenReturn(null);
     final SendStep step = new SendStep("message");
     step.setRoom("room");
     stepExecution = new SendStep.SendStepExecution(step, contextMock);
@@ -146,6 +153,8 @@ public class SendStepTest {
 
   @Test
   public void testFailOnErrorFalseDoesNotThrowsAbortException() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_DEFAULT_ROOM")).thenReturn(null);
     final SendStep step = new SendStep("message");
     step.setFailOnError("false");
     stepExecution = new SendStep.SendStepExecution(step, contextMock);
@@ -160,6 +169,9 @@ public class SendStepTest {
 
   @Test
   public void testSuccessfulMessageSend() throws Exception {
+    when(envVarsMock.get("HUBOT_URL")).thenReturn("http://localhost:9090/");
+    when(envVarsMock.get("HUBOT_FAIL_ON_ERROR")).thenReturn(null);
+    when(envVarsMock.get("CHANGE_AUTHOR")).thenReturn(null);
     final SendStep step = new SendStep("message");
     step.setRoom("room");
     stepExecution = new SendStep.SendStepExecution(step, contextMock);


### PR DESCRIPTION
# Description

I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testWithEmptyHubotURLThrowsAbortException`:

* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"BUILD_URL"`
ii) during test execution the method is actually called with argument `"HUBOT_FAIL_ON_ERROR"`, resulting in a mismatch stubbing

In the test `testWithEmptyRoomThrowsAbortException`:

* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"HUBOT_URL"`
ii) is also stubbed in the `setup` method with argument `"BUILD_URL"`
iii) during test execution the method is actually called with argument `"HUBOT_DEFAULT_ROOM"`, resulting in a mismatch stubbing
iv) during test execution the method is actually called with argument `"HUBOT_FAIL_ON_ERROR"`, resulting in another mismatch stubbing

In the tests `testErrorMessageSend` and `testSuccessfulMessageSend`:
* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"BUILD_URL"`
ii) during test execution the method is actually called with argument `"HUBOT_FAIL_ON_ERROR"`, resulting in a mismatch stubbing
iii) during test execution the method is actually called with argument `"CHANGE_AUTHOR"`, resulting in another mismatch stubbing

 In the test `testFailOnErrorFalseDoesNotThrowsAbortException`:
* The `get` method for the `envVarsMock` object:
i) is stubbed in the `setup` method with argument `"BUILD_URL"`
ii) during test execution the method is actually called with argument `"HUBOT_DEFAULT_ROOM"`, resulting in a mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate. (Not applicable)
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests. (Not applicable)
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given